### PR TITLE
Bug 875: [Github] Enhance the current source: WebAppNetCore in github

### DIFF
--- a/src/CSharp/WebAppNetCore/WebAppNetCore/ConfigurationExtensions.cs
+++ b/src/CSharp/WebAppNetCore/WebAppNetCore/ConfigurationExtensions.cs
@@ -11,26 +11,32 @@ namespace WebAppNetCore
         {
             return configuration["OpenIdConnectOptions:Scope"];
         }
+
         public static string ClientId(this IConfiguration configuration)
         {
             return configuration["OpenIdConnectOptions:ClientId"];
         }
+
         public static string ClientSecret(this IConfiguration configuration)
         {
             return configuration["OpenIdConnectOptions:ClientSecret"];
         }
+
         public static string ResponseType(this IConfiguration configuration)
         {
             return configuration["OpenIdConnectOptions:ResponseType"];
         }
+
         public static string ResponseMode(this IConfiguration configuration)
         {
             return configuration["OpenIdConnectOptions:ResponseMode"];
         }
+
         public static string ClaimsIssuer(this IConfiguration configuration)
         {
             return configuration["OpenIdConnectOptions:ClaimsIssuer"].TrimEnd('/');
         }
+
         public static string IssuerDomain(this IConfiguration configuration)
         {
             return configuration["OpenIdConnectOptions:IssuerDomain"].TrimEnd('/');
@@ -54,11 +60,6 @@ namespace WebAppNetCore
         public static string EndSessionEndpoint(this IConfiguration configuration)
         {
             return configuration.IssuerDomain() + "/runtime/openidconnect/logout.idp";
-        }
-
-        public static X509Certificate2 IssuerSigningKey(this IConfiguration configuration)
-        {
-            return new X509Certificate2(Convert.FromBase64String(configuration["OpenIdConnectOptions:TokenValidationParameters:IssuerSigningKey"]));
         }
 
         public static Uri EditMyProfileUri(this IConfiguration configuration)

--- a/src/CSharp/WebAppNetCore/WebAppNetCore/CustomOpenIdConnectAuthenticationExtension.cs
+++ b/src/CSharp/WebAppNetCore/WebAppNetCore/CustomOpenIdConnectAuthenticationExtension.cs
@@ -44,6 +44,7 @@ namespace WebAppNetCore
             connectOptions.UseTokenLifetime = true;
             connectOptions.SaveTokens = true;
             connectOptions.ClaimsIssuer = configuration.ClaimsIssuer();
+            connectOptions.Authority = configuration.ClaimsIssuer();
             connectOptions.GetClaimsFromUserInfoEndpoint = true;
             connectOptions.UsePkce = configuration.UsePKCE();
 
@@ -59,15 +60,6 @@ namespace WebAppNetCore
 
             connectOptions.AuthenticationMethod = configuration.AuthorizationEndpointMethod();
 
-            connectOptions.Configuration = new OpenIdConnectConfiguration()
-            {
-                AuthorizationEndpoint = configuration.AuthorizationEndpoint(),
-                TokenEndpoint = configuration.TokenEndpoint(),
-                UserInfoEndpoint = configuration.UserInfoEndpoint(),
-                EndSessionEndpoint = configuration.EndSessionEndpoint(),
-                
-                HttpLogoutSupported = true
-            };
             connectOptions.Events = new OpenIdConnectEvents
             {
                 OnRedirectToIdentityProvider = async (context) =>
@@ -166,11 +158,6 @@ namespace WebAppNetCore
                 connectOptions.Scope.Add(scope);
             }
 
-            var signingKey = configuration.IssuerSigningKey();
-            connectOptions.TokenValidationParameters.IssuerSigningKeys = new List<SecurityKey> {
-                new RsaSecurityKey(signingKey.GetRSAPublicKey().ExportParameters(false)),
-                new X509SecurityKey(signingKey)
-            };
             connectOptions.TokenValidationParameters.ValidateAudience = true;   // by default, when we don't explicitly set ValidAudience, it is set to ClientId
             connectOptions.TokenValidationParameters.ValidateIssuer = true;
             connectOptions.TokenValidationParameters.ValidIssuer = configuration.ClaimsIssuer();

--- a/src/CSharp/WebAppNetCore/WebAppNetCore/appsettings.json
+++ b/src/CSharp/WebAppNetCore/WebAppNetCore/appsettings.json
@@ -13,24 +13,21 @@
     }
   },
   "OpenIdConnectOptions": {
-    "ClientId": "client id _ 1K5k3//foPM=",
+    "ClientId": "oidc-code-flow",
     // For demo purpose only. You should store client secret somewhere that is more secure.
-    "ClientSecret": "client secret _ swG01P4IBkMcu+5lH0BLzXhUDrkSejaJqYlGlwVdI9IwIlf2k+mTfgXCD051fCZJJtDgixm7C5H2qP5fTk6TMg==",
+    "ClientSecret": "client_secret",
     "ResponseType": "code",
-    "RequireNonce": "false",
+    "RequireNonce": "true",
     "ResponseMode": "",
-    "UsePKCE": "false",
+    "UsePKCE": "true",
     "AuthorizationEndpointMethod": "GET", // GET or POST
     // You need to add this site to trusted site with highest security mode of Internet Explorer.
-    "ClaimsIssuer": "https://dev55.safewhere.local/runtime/oauth2",
-    "IssuerDomain": "https://dev55.safewhere.local",
-    "EditMyProfileUri": "https://dev55.safewhere.local/adminv2/edit-my-profile",
+    "ClaimsIssuer": "https://dev.safewhere.local/runtime/oauth2",
+    "IssuerDomain": "https://dev.safewhere.local",
+    "EditMyProfileUri": "https://dev.safewhere.local/adminv2/edit-my-profile",
     "Scope": "openid",
-    "EnableSessionManagement": "false",
-    "EnablePostLogout": "false",
-    "CheckSessionIframeUri": "https://dev55.safewhere.local/runtime/openidconnect/sessionlogout.idp",
-    "TokenValidationParameters": {
-      "IssuerSigningKey": "MIIDYTCCAsqgAwIBAgIQwFRaBL5xNbFGRPG2/1LnSDANBgkqhkiG9w0BAQsFADBJMRMwEQYKCZImiZPyLGQBGRYDbmV0MRkwFwYKCZImiZPyLGQBGRYJc2FmZXdoZXJlMRcwFQYDVQQDEw5TYWZld2hlcmUgQ0EgMjAeFw0wOTEyMzExNzAwMDBaFw0zMDEyMzAxNzAwMDBaMHoxCzAJBgNVBAYTAkRLMRMwEQYDVQQIEwpDb3BlbmhhZ2VuMRMwEQYDVQQHEwpEZXYgQnVua2VyMRIwEAYDVQQKEwlTYWZld2hlcmUxDDAKBgNVBAsTA0RldjEfMB0GA1UEAxMWSWRlbnRpZnlEZWZhdWx0U2lnbmluZzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKUQ7b7MtVFTBtfSz+8Jxjbt/ItNzDokOYx0shjqInIfXUFlzdPYOoiYroBXa4sgD0+wSdIXgDRUWl+eIGmqcRH1xk7BJA7tFpv63cKJiaO0zC60GfzWSjcOUKigodVO2wElks2xNT4ASvJNxEK5KYV9+8prFW5v4k+dyyHgdYWU3b9mmrU4p2b5msWO+9tny+azlU3dB+nEdy+SZ65Jvfzp1xjeWOzN4jQ42AmHiRZRnsUeU3xn4We404bZ9NPL14BbNYKEF3sMB/8cIc7rKW09xWN1wi2EIHQY5Msm0fpWCZUwYCcnwW4K/qgp3Uc0yfbxKDqDSo/pluYQeCwfWo8CAwEAAaOBlDCBkTATBgNVHSUEDDAKBggrBgEFBQcDATB6BgNVHQEEczBxgBAFQDRik9fSAavzW0IEXV98oUswSTETMBEGCgmSJomT8ixkARkWA25ldDEZMBcGCgmSJomT8ixkARkWCXNhZmV3aGVyZTEXMBUGA1UEAxMOU2FmZXdoZXJlIENBIDKCEFml1D7IO163RfencPmdPmwwDQYJKoZIhvcNAQELBQADgYEANHyflZiSVAtmOBwfevURrRVTaRbzcBMi14+FrYIet2z22afRoY8jnJqcHN2w7z/gwn1MNPNYo0Bz3NL8tMXm2DNRle6E0EhcKB3979L6p8XvIkvZmZtDWy0WSQeAlz6R5BA5tp0vYmV/GkgUWWoHLQw5VIU/gYBDCdMkvtZrJrA="
-    }
+    "EnableSessionManagement": "true",
+    "EnablePostLogout": "true",
+    "CheckSessionIframeUri": "https://dev.safewhere.local/runtime/openidconnect/sessionlogout.idp",
   }
 }

--- a/src/CSharp/WebAppNetCore/WebAppNetCore/wwwroot/css/site.css
+++ b/src/CSharp/WebAppNetCore/WebAppNetCore/wwwroot/css/site.css
@@ -29,6 +29,10 @@ textarea {
     width: 100%;
 }
 
+.input-group a.btn-primary {
+    margin-right: 15px;
+}
+
 /* Hide/rearrange for smaller screens */
 @media screen and (max-width: 767px) {
     /* Hide captions */


### PR DESCRIPTION
Changes to **OpenIdConnectOptions**:

- Remove **Configuration** property and **TokenValidationParameters.IssuerSigningKeys**

  + Set **Authority** to the Claim Issuer endpoint.
  
  + The middleware will automatically fetch OIDC metadata from _"/.well-known/openid-configuration"_ (including endpoints and signing keys).

- Remove **IssuerSigningKey** from **appsettings.json**
